### PR TITLE
Clean the potntial trailing / or /. off the PWD path.

### DIFF
--- a/package/pkg-kernel-module.mk
+++ b/package/pkg-kernel-module.mk
@@ -65,15 +65,18 @@ $(2)_MODULE_SUBDIRS ?= .
 # Build the kernel module(s)
 # Force PWD for those packages that want to use it to find their
 # includes and other support files (Booo!)
+# Plus additional patch to prevent trailing /. in the PWD path (3/28/2024)
 define $(2)_KERNEL_MODULES_BUILD
 	@$$(call MESSAGE,"Building kernel module(s)")
 	$$(foreach d,$$($(2)_MODULE_SUBDIRS), \
+		$(eval _PWD := $$(patsubst %/.,%,$$(patsubst %/,%,$$(@D)/$$(d)))) \
+		$(eval _M := $$(patsubst %/.,%,$$(patsubst %/,%,$$(@D)/$$(d)))) \
 		$$(LINUX_MAKE_ENV) $$($$(PKG)_MAKE) \
 			-C $$(LINUX_DIR) \
 			$$(LINUX_MAKE_FLAGS) \
 			$$($(2)_MODULE_MAKE_OPTS) \
-			PWD=$$(@D)/$$(d) \
-			M=$$(@D)/$$(d) \
+			PWD=$$(_PWD) \
+			M=$$(_M) \
 			modules$$(sep))
 endef
 $(2)_POST_BUILD_HOOKS += $(2)_KERNEL_MODULES_BUILD

--- a/package/pkg-kernel-module.mk
+++ b/package/pkg-kernel-module.mk
@@ -65,19 +65,16 @@ $(2)_MODULE_SUBDIRS ?= .
 # Build the kernel module(s)
 # Force PWD for those packages that want to use it to find their
 # includes and other support files (Booo!)
-# Plus additional patch to prevent trailing /. in the PWD path (3/28/2024)
 define $(2)_KERNEL_MODULES_BUILD
-	@$$(call MESSAGE,"Building kernel module(s)")
-	$$(foreach d,$$($(2)_MODULE_SUBDIRS), \
-		$(eval _PWD := $$(patsubst %/.,%,$$(patsubst %/,%,$$(@D)/$$(d)))) \
-		$(eval _M := $$(patsubst %/.,%,$$(patsubst %/,%,$$(@D)/$$(d)))) \
-		$$(LINUX_MAKE_ENV) $$($$(PKG)_MAKE) \
-			-C $$(LINUX_DIR) \
-			$$(LINUX_MAKE_FLAGS) \
-			$$($(2)_MODULE_MAKE_OPTS) \
-			PWD=$$(_PWD) \
-			M=$$(_M) \
-			modules$$(sep))
+    @$$(call MESSAGE,"Building kernel module(s)")
+    $$(foreach d,$$($(2)_MODULE_SUBDIRS), \
+        $$(LINUX_MAKE_ENV) $$($$(PKG)_MAKE) \
+            -C $$(LINUX_DIR) \
+            $$(LINUX_MAKE_FLAGS) \
+            $$($(2)_MODULE_MAKE_OPTS) \
+            PWD=$$(patsubst %/.,%,$$(patsubst %/,%,$$(@D)/$$(d))) \
+            M=$$(patsubst %/.,%,$$(patsubst %/,%,$$(@D)/$$(d))) \
+            modules$$(sep))
 endef
 $(2)_POST_BUILD_HOOKS += $(2)_KERNEL_MODULES_BUILD
 


### PR DESCRIPTION
This got the /./ path issue fixed in the 4.4 build locally.