### PR TITLE
set ca-certificates bundle path

### DIFF
--- a/package/libcurl/libcurl.mk
+++ b/package/libcurl/libcurl.mk
@@ -85,6 +85,7 @@ endif
 
 ifeq ($(BR2_PACKAGE_LIBCURL_MBEDTLS),y)
 LIBCURL_CONF_OPTS += --with-mbedtls=$(STAGING_DIR)/usr
+LIBCURL_CONF_OPTS += --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt
 LIBCURL_DEPENDENCIES += mbedtls
 else
 LIBCURL_CONF_OPTS += --without-mbedtls


### PR DESCRIPTION
set ca-certificates bundle path, system env no longer needed