### PR TITLE
Remove unnecessary check for spaces in PATH

### DIFF
--- a/support/dependencies/dependencies.sh
+++ b/support/dependencies/dependencies.sh
@@ -38,9 +38,9 @@ case ":${PATH:-unset}:" in
 	echo "PATH environment variable. This doesn't work."
 	exit 1
 	;;
-(*" "*|*"${TAB}"*|*"${NL}"*)
+(*"${TAB}"*|*"${NL}"*)
 	printf "\n"
-	printf "Your PATH contains spaces, TABs, and/or newline (\\\n) characters.\n"
+	printf "Your PATH contains TABs and/or newline (\\\n) characters.\n"
 	printf "This doesn't work. Fix you PATH.\n"
 	exit 1
 	;;


### PR DESCRIPTION
I tried compiling after removing this check and everything happened as expected.

This allows to compile in WSL without further modifications.

Refs https://github.com/themactep/thingino-firmware/issues/355

I also opened an issue against Buildroot for discussion:

- https://gitlab.com/buildroot.org/buildroot/-/issues/76